### PR TITLE
pr-review-queue: Show oldest PR on the top

### DIFF
--- a/pr_review_queue.py
+++ b/pr_review_queue.py
@@ -173,7 +173,7 @@ def list_green_pull_requests(github_api, org, repo, dry_run):
     res = None
 
     try:
-        res = github_api.search.issues_and_pull_requests(q=query, per_page=100, sort="updated",order="desc")
+        res = github_api.search.issues_and_pull_requests(q=query, per_page=100, sort="updated",order="asc")
     except: # pylint: disable=bare-except
         print("Couldn't get any pull requests.")
 


### PR DESCRIPTION
Previously the sort order had been newest on top. We want to work down from the oldest to the latest PRs.