### PR TITLE
ghactions: Activate daily cronjob

### DIFF
--- a/.github/workflows/pr-review-queue.yaml
+++ b/.github/workflows/pr-review-queue.yaml
@@ -3,8 +3,8 @@ name: "PR Review Queue"
 
 on:
   workflow_dispatch:
-  #schedule:
-  #  - cron: '0 8 * * *'
+  schedule:
+    - cron: '0 8 * * 1-5'
 
 jobs:
   weekly:


### PR DESCRIPTION
This means that Monday through Friday the bot will post the pull request review queue at 8:00 AM to the `#osbuild` channel.