### PR TITLE
Fix ci status

### DIFF
--- a/pr_review_queue.py
+++ b/pr_review_queue.py
@@ -52,20 +52,21 @@ def get_check_runs(github_api, repo, head):
     """
     check_runs = github_api.checks.list_for_ref(repo=repo,ref=head, per_page=100)
     runs = check_runs["check_runs"]
+    total_count = check_runs["total_count"]
     successful_runs = 0
 
     for run in runs:
         if run['status'] == "completed" and run['conclusion'] == "success":
             successful_runs += 1
 
-    if successful_runs == len(runs):
-        status = f"success ({successful_runs}/{len(runs)})"
+    if successful_runs == total_count:
+        status = "success"
         state = "🟢"
-    elif successful_runs < len(runs):
-        status = f"failure ({successful_runs}/{len(runs)})"
+    elif successful_runs < total_count:
+        status = "failure"
         state = "🔴"
     else:
-        print(f"Warning: something is terribly wrong: successful runs ({successful_runs}) should never be more than total runs ({len(runs)}).")
+        print(f"Warning: something is terribly wrong: successful runs ({successful_runs}) should never be more than total runs ({total_count}).")
         sys.exit(1)
 
     return status, state


### PR DESCRIPTION
These two commits ensure that our CI status matching improves, however, it's still not perfect.
Previously, we only looked at check_runs status when the `combined_status` was empty. Now we look at the native GitHub actions check_runs in any case, and even avoid an API call if check runs have failed.
This means that effectively we create our own `combined_status` out of external CIs and check runs.

There is still a corner case I'm unsure how to handle. When a PR has checks defined, but they haven't been triggered (I presume that external contributors don't have the permissions in this case?), the API returns `total_count = 0`.
So while the correct state would be `pending`, we cannot know if there are maybe no GitHub checks defined or if they haven't been triggered.
Here's a PR that I ran into with this problem: https://github.com/osbuild/cloud-image-val/pull/283
It's currently part of the queue, even though CI hasn't run.

We can of course also decide to ignore this corner case because there may not be a pretty solution to it.