### PR TITLE
pr-review-queue: Avoid Slack line wrapping

### DIFF
--- a/pr_review_queue.py
+++ b/pr_review_queue.py
@@ -29,17 +29,7 @@ def slack_notify(message:str, dry_run: bool):
 
     if url:
         webhook = WebhookClient(url)
-        response = webhook.send(
-            text="fallback",
-            blocks=[
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"<{github_url}|pr-review-queue>: {message}"
-                    }
-                }
-            ])
+        response = webhook.send(text=f"<{github_url}|pr-review-queue>: {message}")
         assert response.status_code == 200, f"Error {response.status_code}\n{response.body}"
         assert response.body == "ok"
     else:


### PR DESCRIPTION
Currently, Slack wraps each line at around 100 characters, which causes unnecessary line breaks in the list of PRs.
To avoid this, simply send a text message and avoid blocks. This is not explained in the Slack API reference, unfortunately, but in this StackOverflow:
https://stackoverflow.com/questions/58797144/slack-webapi-block-section-dont-wrap-line-of-text